### PR TITLE
Display Number of Players Capping on Payload.

### DIFF
--- a/info.vdf
+++ b/info.vdf
@@ -1,4 +1,4 @@
-"m0rehud"
+"delihudneue"
 {
 	"ui_version"	"3"
 }

--- a/resource/ui/objectivestatusescort.res
+++ b/resource/ui/objectivestatusescort.res
@@ -166,8 +166,8 @@
 		{	
 			"ControlName"							"CExLabel"
 			"fieldName"								"CapNumPlayers"
-			"font"									"Size 9"
-			"xpos"									"125"
+			"font"									"m0refont10"
+			"xpos"									"119"
 			"ypos"									"0"
 			"zpos"									"30"
 			"wide"									"20"
@@ -178,11 +178,10 @@
 			"visible"								"0"
 			"enabled"								"1"
 			"labelText"								"#ControlPointIconCappers"
-			"textAlignment"							"center"
+			"textAlignment"							"east"
 			"dulltext"								"0"
 			"brighttext"							"0"
 			"fgcolor"								"white"
-			"paintbackground"						"0"
 			"proportionaltoparent"					"1"
 			"use_proportional_insets"				"1"
 		}


### PR DESCRIPTION
- Minor change to display the number of players on the cart in payload (been using this hud a long time, and this always bothered me).

Example:
![delihudneue-payload](https://github.com/user-attachments/assets/ec822a52-46cd-4607-82a4-80063ce059de)
